### PR TITLE
Run node tests when coverage is configured for `node`

### DIFF
--- a/modules/dev-tools/scripts/test.sh
+++ b/modules/dev-tools/scripts/test.sh
@@ -65,7 +65,7 @@ case $MODE in
 
   "ci")
     # run by CI
-    if [ "$COVERAGE_TEST" == "browser" ]; then
+    if [ "$COVERAGE_TEST" == "node" ]; then
       run_test_script_pretty node
     else
       run_test_script_pretty browser-headless


### PR DESCRIPTION
Closes #10

```
// .ocularrc.js
coverage: {
  test: 'browser' // now runs headless-browser tests in CI
},
```

```
// .ocularrc.js
coverage: {
  test: 'node' // runs node tests in CI
},
```